### PR TITLE
Load tasks for initially selected project on safari

### DIFF
--- a/bamboohr-timesheet-data-entry.user.js
+++ b/bamboohr-timesheet-data-entry.user.js
@@ -23,6 +23,14 @@ function appendScript(fn) {
   targ.appendChild(script)
 }
 
+function onPageLoad(fn) {
+  if (document.readyState !== 'loading') {
+    setTimeout(fn, 0);
+  } else {
+    document.addEventListener('DOMContentLoaded', fn, false);
+  }
+}
+
 (async function() {
 
   let tsd = JSON.parse(document.getElementById('js-timesheet-data').innerHTML);
@@ -116,9 +124,7 @@ function appendScript(fn) {
     document.getElementById('MyProjectSelector').onchange = on_change;
     
     // Call once when then page loads for the first selected project
-    document.addEventListener('DOMContentLoaded', function() {
-      on_change();
-    }, false);
+    onPageLoad(on_change);
   }
   
   appendScript(add_project_onchange);


### PR DESCRIPTION
I think I'm running into this issue: https://developer.apple.com/forums/thread/651215

The effect of this is that when I first load the page the tasks aren't loaded for the initially selected project.
If I selected a different project and then reselected the initial project it worked just fine.